### PR TITLE
Optimize Docker build context and fix frontend Tailwind configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Ignore git and development files
+.git
+.gitignore
+Dockerfile*
+docker-compose*
+README.md
+*.md
+**/bin/
+**/obj/
+frontend/
+node_modules/
+.vscode/
+.venv/
+*.log
+

--- a/NFe.API/Dockerfile
+++ b/NFe.API/Dockerfile
@@ -7,8 +7,7 @@ COPY *.sln ./
 COPY NFe.API/*.csproj ./NFe.API/
 COPY NFe.Core/*.csproj ./NFe.Core/
 COPY NFe.Infrastructure/*.csproj ./NFe.Infrastructure/
-COPY NFe.Shared/*.csproj ./NFe.Shared/
-
+ 
 # Restore dependencies
 RUN dotnet restore NFe.API/NFe.API.csproj
 
@@ -16,7 +15,6 @@ RUN dotnet restore NFe.API/NFe.API.csproj
 COPY NFe.API/ ./NFe.API/
 COPY NFe.Core/ ./NFe.Core/
 COPY NFe.Infrastructure/ ./NFe.Infrastructure/
-COPY NFe.Shared/ ./NFe.Shared/
 
 # Build and publish
 RUN dotnet publish NFe.API/NFe.API.csproj -c Release -o /app/publish \

--- a/NFe.Worker/Dockerfile
+++ b/NFe.Worker/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /src
 COPY *.sln ./
 COPY NFe.Core/*.csproj ./NFe.Core/
 COPY NFe.Infrastructure/*.csproj ./NFe.Infrastructure/
-COPY NFe.Shared/*.csproj ./NFe.Shared/
 COPY NFe.Worker/*.csproj ./NFe.Worker/
 
 # Restore dependencies
@@ -15,7 +14,6 @@ RUN dotnet restore NFe.Worker/NFe.Worker.csproj
 # Copy only required source code for Worker and dependencies
 COPY NFe.Core/ ./NFe.Core/
 COPY NFe.Infrastructure/ ./NFe.Infrastructure/
-COPY NFe.Shared/ ./NFe.Shared/
 COPY NFe.Worker/ ./NFe.Worker/
 
 # Build and publish

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NFe Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nfe-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.4.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">NFe Frontend</h1>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}


### PR DESCRIPTION
## Summary
- Reduce Docker build context with a new `.dockerignore` and streamline API/Worker Dockerfiles.
- Scaffold a minimal Vite + React frontend and correct PostCSS Tailwind plugin configuration.

## Testing
- `docker compose up -d --build` *(fails: command not found)*
- `npm install` *(fails: 403 Forbidden reaching registry)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d292b720832ea49614d1bfe07de2